### PR TITLE
Fix comment typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build --chown=65532:65532 /app/dependencies /app/dependencies
 # Setting an environment variable so Python knows where to find the dependencies
 ENV PYTHONPATH=/app/dependencies
 
-# Enviroment Variables for database connection
+# Environment Variables for database connection
 ENV DATABASE_HOST= \
     DATABASE_NAME= \
     DATABASE_USER= \


### PR DESCRIPTION
## Summary
- fix a misspelling of *Environment* in Dockerfile comment

## Testing
- `python -m py_compile todo_app.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68840f84751483279839c36f084fdae1