### PR TITLE
Add rowcount checks for task updates

### DIFF
--- a/todo_app.py
+++ b/todo_app.py
@@ -176,6 +176,10 @@ class TodoManager:
         """
         try:
             self.cur.execute(update_query, (status.value, task_id))
+            if self.cur.rowcount == 0:
+                self.conn.rollback()
+                print(f"No task found with ID: {task_id}")
+                return False
             self.conn.commit()
             print(f"Task {task_id} status updated to {status.value}")
             return True
@@ -250,6 +254,10 @@ class TodoManager:
         """
         try:
             self.cur.execute(update_query, (title, description, task_id))
+            if self.cur.rowcount == 0:
+                self.conn.rollback()
+                print(f"No task found with ID: {task_id}")
+                return False
             self.conn.commit()
             print(f"Task {task_id} updated successfully")
             return True


### PR DESCRIPTION
## Summary
- check `rowcount` after updating task status or title/description
- rollback and return `False` if no rows were affected

## Testing
- `python -m py_compile todo_app.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688410123d348327a3035b384f4be004