### PR TITLE
Fix Dockerfile comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use any Node.js base image that you want (as long as it's Alpine)!
+# Use a Python base image with a specified version
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim AS build
 


### PR DESCRIPTION
## Summary
- clarify Dockerfile's opening comment to note that it uses a Python base image

## Testing
- `python -m py_compile todo_app.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884109a3b488327b0ae0bf57096e1f5